### PR TITLE
Adding Informational description above subgoal and action tree

### DIFF
--- a/templates/popup.html
+++ b/templates/popup.html
@@ -52,10 +52,11 @@
 	</div>
 <hr>
 <div id="sideBySide" style="overflow-y:auto; overflow-x:hidden;">
-	<nav id="subgoalList" style="height:80%; width:10%; float:left"></nav>
-		<div id="treeInfo" style="margin:5px;" hidden>
-			<label id="infoText"> Click on subgoals and actions in the tree below to view or edit them</span>
-	    </div>
+	<nav id="subgoalList" style="height:80%; width:10%; float:left">
+        <div id="treeInfo" style="margin:5px;" hidden>
+            <label id="infoText"> Click on subgoals and actions in the tree below to view or edit them</span>
+        </div>
+    </nav>
 	<div id="containeryo" style="height:80%; width:50%; margin:5px;  float:left; overflow-y: auto; overflow-x:hidden;" >
 		<div id="setup" class="instruction" style="margin-bottom:5px;">
 			<!--span class="preview"> Before you get started with the GenderMag walkthrough... </span-->

--- a/templates/popup.html
+++ b/templates/popup.html
@@ -53,6 +53,9 @@
 <hr>
 <div id="sideBySide" style="overflow-y:auto; overflow-x:hidden;">
 	<nav id="subgoalList" style="height:80%; width:10%; float:left"></nav>
+		<div id="treeInfo" style="margin:5px;" hidden>
+			<label id="infoText"> Click on subgoals and actions in the tree below to view or edit them</span>
+	    </div>
 	<div id="containeryo" style="height:80%; width:50%; margin:5px;  float:left; overflow-y: auto; overflow-x:hidden;" >
 		<div id="setup" class="instruction" style="margin-bottom:5px;">
 			<!--span class="preview"> Before you get started with the GenderMag walkthrough... </span-->

--- a/ui/uiController.js
+++ b/ui/uiController.js
@@ -52,7 +52,7 @@ function addToSandwich(type, item){
             // add the new subgoal to the sidebar
             if (!foundIt) {
                 sidebarBody().find("#subgoalList").append(sideSubgoal);
-				sidebarBody().find("#treeInfo").show();
+                sidebarBody().find("#treeInfo").show();
             }
             
         }

--- a/ui/uiController.js
+++ b/ui/uiController.js
@@ -52,6 +52,7 @@ function addToSandwich(type, item){
             // add the new subgoal to the sidebar
             if (!foundIt) {
                 sidebarBody().find("#subgoalList").append(sideSubgoal);
+				sidebarBody().find("#treeInfo").show();
             }
             
         }


### PR DESCRIPTION
---
name: Pull request template
about: GenderMag Recorders Assistant project

---

* **What does this implementation fix? Explain your changes.**
This implementation adds a small text description above the tree, stating its purpose to allow users to view and edit past subgoals and actions: " Click on subgoals and actions in the tree below to view or edit them ". It only appears once a subgoal is made and the tree is visible. 

* **Does this close any open issue? (Give issue id from issue tracker)**
Yes, it closes issue #61  (Add a message that shows the tree as editable)

* **Include any related logs, error, output file etc.**
N/A

* **Did you test on Mac and Windows?**
I've tested it on Mac as well as Mac's bootcamp (essentially runs windows on Mac) as I do not have access to a window's device though I recognize that there still might be discrepancies between that and a real windows device. 

* **Did you test the full GM process and verify that the code does not contribute any unexpected errors/bugs?**
Yes. The entire process and output log seemed as it should be. 

* **Did you follow the style guidelines and verify that the code does not have any incorrect formatting?**
Yes

* **If possible, provide a screenshot of the functionality.**
Example of UI before subgoals are made:
<img width="1440" alt="Screenshot 2025-06-03 at 2 30 19 AM" src="https://github.com/user-attachments/assets/060540db-f8b3-4b5a-b141-1a1579230ed0" />

Example of UI after initial subgoal is made:
<img width="1440" alt="Screenshot 2025-06-03 at 2 31 08 AM" src="https://github.com/user-attachments/assets/a2331d82-2ea0-4009-b518-85ba7e2f64b9" />

* **Any other information?**
Of course if this is approved, feel free to edit the little text blurb to make it more concise / educational