### PR TITLE
fixed broken link on line 29 of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Contributing</a>.
 * [Download Chrome](https://www.google.com/chrome/)
 * Short paper: [The GenderMag Recorder’s Assistant](https://ieeexplore.ieee.org/document/8506505) 
 * Long paper (Research Study): [Semi-Automating (or not) a Socio-Technical Method for Socio-Technical Systems](https://ieeexplore.ieee.org/document/8506514)
-* [Video](https://www.youtube.com/watch?v=GOy7Aq5lozQ) using the GenderMag Recorder's Assistant.
+* [Video](https://www.youtube.com/watch?v=YQwElUH1Wvs) using the GenderMag Recorder's Assistant.
     
 # How does GenderMag make software more inclusive?</h1>
 


### PR DESCRIPTION
What does this implementation fix? Explain your changes.
 This implementation fixes the broken YouTube link in README.md. In this implementation, when the link is clicked, the user is take to a helpful demonstration of four cognitive styles used when interacting with software. This video is also embedded in the "what is it" portion of GenderMag Project's website.[Here is a link](https://gendermag.org/gendermag.php) to the embedded video I am referencing.


Does this close any open issue? (Give issue id from issue tracker)
 This closes issue[ README.md Document - How to Run a GenderMag Session Using the Tool - Section Update (Video Links) GenderMagProject/GenderMagRecordersAssistant#181](https://github.com/GenderMagProject/GenderMagRecordersAssistant/issues/181)


Include any related logs, error, output file etc.
 N/A


Did you test on Mac and Windows?
 N/A


Did you test the full GM process and verify that the code does not contribute any unexpected errors/bugs?
 N/A


Did you follow the style guidelines and verify that the code does not have any incorrect formatting?
 N/A


If possible, provide a screenshot of the functionality.
 N/A


Any other information?
 There is another video on GenderMag Project's YouTube channel that could be helpful here instead. Specifically,[ this playlist](https://www.youtube.com/watch?v=ucY8-tHD134&list=PLowUoiojdbAvQHSiUV4o7FsxcDX--JgCq) which is an extensive walkthrough.